### PR TITLE
feat: Allow reclaiming only anon or file pages from coldest generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ sudo ./age-reclaim.py /sys/fs/cgroup/ws --print-debug-stats --reclaim 120
 In the debug statistics of the tool, you should see a percentage of the cgroup's memory moved
 to the lower tier's NUMA node(s) after approximately 120 seconds.
 
+> [!NOTE]
+> By default, the tool reclaims both `anon` and `file` pages but it can be configured to reclaim
+> only `anon` or only `file` pages if desired. See `--help` for more details.
+
 ## How It Works
 
 This script leverages the Linux kernel's Multi-Gen LRU debugfs API to monitor page coldness within a cgroup and optionally reclaim cold pages based on an age threshold.


### PR DESCRIPTION
This commit adds the arguments `--anon BOOL` and `--file BOOL` to age-reclaim.py. These flags allow the user to configure the tool to either reclaim only anon pages, only file pages, or both.

This is achieved by using the optional arguments `swappiness` and `nr_to_reclaim` in the [MGLRU's debugfs](https://docs.kernel.org/admin-guide/mm/multigen_lru.html):

```
- memcg_id node_id min_gen_nr [swappiness [nr_to_reclaim]]
```

- To reclaim only anon pages the tool sets swappiness=MAX_SWAPPINESS and nr_to_reclaim=nr_anon
- To reclaim only file pages the tool sets swappiness=1 and nr_to_reclaim=nr_file
- To reclaim all pages, the tool does not pass any optional arguments

The implementation details for the swappiness can be found in the linux kernel source `mm/vmscan.c:isolate_folios()`. In short, swappiness=1 will start from file pages and swappiness=MAX_SWAPPINESS will start from anonymous pages. Since we request a reclaim of a number of pages equal to the pages of the relevant type (anon or file), the reclaim will only move these pages (with a small error possible due to the MGLRU counts being updated between the tool reading them and the tool sending the command).

The commit also refactors the reclaim command to print informative messages for the three kinds of reclaims (anon, file, or both).